### PR TITLE
Switch to or add Fantom network to Metamask

### DIFF
--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -121,7 +121,7 @@ export default function WalletModal(): JSX.Element {
             setWalletView(WALLET_VIEWS.ACCOUNT)
         }
     }, [walletModalOpen])
-    
+
     // close modal when a connection is successful
     const activePrevious = usePrevious(active)
     const connectorPrevious = usePrevious(connector)
@@ -147,9 +147,9 @@ export default function WalletModal(): JSX.Element {
             activate(connector, undefined, true).catch((error) => {
                 if (error instanceof UnsupportedChainIdError) {
                     switchOrAddChain(FANTOM_NETWORK).then((res) => {
-                        if(!res){
+                        if (!res) {
                             setPendingError(true)
-                            activate(connector) // No need to activate again if switch was successful 
+                            activate(connector) // No need to activate again if switch was successful
                         }
                     })
                 } else {
@@ -246,20 +246,14 @@ export default function WalletModal(): JSX.Element {
     }
 
     function getModalContent() {
-        if (error && (error instanceof UnsupportedChainIdError) === false) {
+        if (error && error instanceof UnsupportedChainIdError === false) {
             return (
                 <UpperSection>
                     <CloseIcon onClick={toggleWalletModal}>
                         <CloseColor />
                     </CloseIcon>
-                    <HeaderRow>
-                        Error connecting
-                    </HeaderRow>
-                    <ContentWrapper>
-
-                            Error connecting. Try refreshing the page.
-                        
-                    </ContentWrapper>
+                    <HeaderRow>Error connecting</HeaderRow>
+                    <ContentWrapper>Error connecting. Try refreshing the page.</ContentWrapper>
                 </UpperSection>
             )
         }

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -58,7 +58,7 @@ function Web3StatusInner() {
                 {connector && <StatusIcon connector={connector} />}
             </div>
         )
-    } else if (error && (error instanceof UnsupportedChainIdError) === false) {
+    } else if (error && error instanceof UnsupportedChainIdError === false) {
         return (
             <button className="rounded-lg py-2 px-4 m-2 bg-custom-red" onClick={toggleWalletModal}>
                 <p>Error</p>

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -58,10 +58,10 @@ function Web3StatusInner() {
                 {connector && <StatusIcon connector={connector} />}
             </div>
         )
-    } else if (error) {
+    } else if (error && (error instanceof UnsupportedChainIdError) === false) {
         return (
             <button className="rounded-lg py-2 px-4 m-2 bg-custom-red" onClick={toggleWalletModal}>
-                <p>{error instanceof UnsupportedChainIdError ? 'You are on the wrong network' : 'Error'}</p>
+                <p>Error</p>
             </button>
         )
     } else {

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -1,3 +1,4 @@
+import { AddEthereumChainParameter } from 'hooks/useSwitchOrAddChain'
 import Fantom from '../assets/networks/fantom-network.jpg'
 
 export enum ChainId {
@@ -66,4 +67,18 @@ export function calcAPCost(score: number): number {
     } else {
         return Math.floor((score - 8) ** 2 / 6)
     }
+}
+
+
+export const FANTOM_NETWORK: AddEthereumChainParameter = {
+    chainId: "0xfa",
+    chainName: "Fantom Opera",
+    nativeCurrency: {
+        name: "Fantom",
+        symbol: "FTM",
+        decimals: 18
+    },
+    rpcUrls: ["https://rpc.ftm.tools/"],
+    blockExplorerUrls: ["https://ftmscan.com/"],
+
 }

--- a/src/hooks/useSwitchOrAddChain.ts
+++ b/src/hooks/useSwitchOrAddChain.ts
@@ -1,41 +1,51 @@
-import { useCallback } from "react";
+import { useCallback } from 'react'
 
 export interface AddEthereumChainParameter {
-    chainId: string; // A 0x-prefixed hexadecimal string
-    chainName: string;
+    chainId: string // A 0x-prefixed hexadecimal string
+    chainName: string
     nativeCurrency: {
-      name: string;
-      symbol: string; // 2-6 characters long
-      decimals: 18;
-    };
-    rpcUrls: string[];
-    blockExplorerUrls?: string[];
-    iconUrls?: string[]; // Currently ignored.
-  }
+        name: string
+        symbol: string // 2-6 characters long
+        decimals: 18
+    }
+    rpcUrls: string[]
+    blockExplorerUrls?: string[]
+    iconUrls?: string[] // Currently ignored.
+}
 
-export function useSwitchOrAddChain(): (params: AddEthereumChainParameter) => Promise<boolean>{
+export function useSwitchOrAddChain(): (params: AddEthereumChainParameter) => Promise<boolean> {
     return useCallback(async (params: AddEthereumChainParameter) => {
-        if(window.ethereum && window.ethereum.request){
-            return window.ethereum.request({method: "wallet_switchEthereumChain", params: [{
-              chainId: params.chainId
-            }]}).then(() => true).catch((switchError) => {
-              if(switchError.code === 4902){
-                if(window.ethereum && window.ethereum.request){
-                  return window.ethereum?.request({
-                    method: "wallet_addEthereumChain",
-                    params: [params]
-                  }).then(res => true).catch(addError => {
-                    console.debug(`Can not add network: ${addError.message}`)
-                    return false;
-                  })
-                }
-              }
-              console.debug(`Can not switch network: ${switchError.message}`)
-              return false
-            })
+        if (window.ethereum && window.ethereum.request) {
+            return window.ethereum
+                .request({
+                    method: 'wallet_switchEthereumChain',
+                    params: [
+                        {
+                            chainId: params.chainId,
+                        },
+                    ],
+                })
+                .then(() => true)
+                .catch((switchError) => {
+                    if (switchError.code === 4902) {
+                        if (window.ethereum && window.ethereum.request) {
+                            return window.ethereum
+                                ?.request({
+                                    method: 'wallet_addEthereumChain',
+                                    params: [params],
+                                })
+                                .then((res) => true)
+                                .catch((addError) => {
+                                    console.debug(`Can not add network: ${addError.message}`)
+                                    return false
+                                })
+                        }
+                    }
+                    console.debug(`Can not switch network: ${switchError.message}`)
+                    return false
+                })
         }
-        console.debug("Can not switch network: Window.ethereum is undefined")
+        console.debug('Can not switch network: Window.ethereum is undefined')
         return false
-    
     }, [])
 }

--- a/src/hooks/useSwitchOrAddChain.ts
+++ b/src/hooks/useSwitchOrAddChain.ts
@@ -1,0 +1,41 @@
+import { useCallback } from "react";
+
+export interface AddEthereumChainParameter {
+    chainId: string; // A 0x-prefixed hexadecimal string
+    chainName: string;
+    nativeCurrency: {
+      name: string;
+      symbol: string; // 2-6 characters long
+      decimals: 18;
+    };
+    rpcUrls: string[];
+    blockExplorerUrls?: string[];
+    iconUrls?: string[]; // Currently ignored.
+  }
+
+export function useSwitchOrAddChain(): (params: AddEthereumChainParameter) => Promise<boolean>{
+    return useCallback(async (params: AddEthereumChainParameter) => {
+        if(window.ethereum && window.ethereum.request){
+            return window.ethereum.request({method: "wallet_switchEthereumChain", params: [{
+              chainId: params.chainId
+            }]}).then(() => true).catch((switchError) => {
+              if(switchError.code === 4902){
+                if(window.ethereum && window.ethereum.request){
+                  return window.ethereum?.request({
+                    method: "wallet_addEthereumChain",
+                    params: [params]
+                  }).then(res => true).catch(addError => {
+                    console.debug(`Can not add network: ${addError.message}`)
+                    return false;
+                  })
+                }
+              }
+              console.debug(`Can not switch network: ${switchError.message}`)
+              return false
+            })
+        }
+        console.debug("Can not switch network: Window.ethereum is undefined")
+        return false
+    
+    }, [])
+}

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -14,6 +14,7 @@ interface Window {
         on?: (...args: any[]) => void
         removeListener?: (...args: any[]) => void
         autoRefreshOnNetworkChange?: boolean
+        request?: (RequestArguments: {method: string, params?: unknown[] | object}) => Promise<unknown>
     }
     web3?: {}
 }


### PR DESCRIPTION
Code to switch to or add Fantom network. It only works on Metamask, because it's the only wallet that implemented this EIP. Hook will first try to switch to network if exists, otherwise it will try to add the network per specs on: https://docs.fantom.foundation/tutorials/set-up-metamask. It handles user rejection and any other error that could occur when switching or adding the network. 